### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests on Multiple OS


### PR DESCRIPTION
Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained instead of inheriting potentially broad defaults.

Best fix for this file: add workflow-level permissions immediately after the `on:` trigger, so all jobs in this workflow inherit least privilege unless overridden. For the current steps, a minimal safe baseline is:

- `contents: read`

This preserves current behavior for checkout and test execution while satisfying CodeQL’s requirement to explicitly limit token permissions.